### PR TITLE
Update Fontello URL (http => https)

### DIFF
--- a/src/Fontello.js
+++ b/src/Fontello.js
@@ -8,7 +8,7 @@ const { RawSource } = require("webpack-sources")
 const HttpsProxyAgent = require('https-proxy-agent')
 
 const defaults = {
-	host: "http://fontello.com",
+	host: "https://fontello.com",
 	proxy: null
 }
 


### PR DESCRIPTION
Fontello now uses SSL, and POST requests are not redirected properly, see https://github.com/fontello/fontello/issues/716.

This PR updates base URL to "proper".